### PR TITLE
consume the jar file in a Docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.pants.d
+/dist
 
 bazel-jvm/bazel-*
 

--- a/BUILD.pants
+++ b/BUILD.pants
@@ -1,4 +1,12 @@
-# This target is what invokes Bazel. The main point to note here is that the `{chroot}` symbol is replaced with the path to the temporary directory used during execution to materialize Pants-supplied inputs. 
+# This target invokes Bazel to produce a jar file. The example is contrived since Pants has JVM support,
+# but the main focal point here is demonstrating Pants invoking a third party build tool and then
+# consuming that tool's output (and not the particular details of this example).
+#
+# Please note that the `{chroot}` symbol is replaced with the path to a temporary directory created
+# during execution to materialize Pants-supplied inputs.
+#
+# Moreover, the `{chroot}` directory is also used by Pants for capturing outputs from this process. (Thus,
+# the jar file is copied to the `{chroot}` directory to make it visible to Pants.)
 shell_command(
   name="bazel-jvm-binary",
   command="bazel build --java_runtime_version=remotejdk_11 :ProjectRunner && cp bazel-bin/ProjectRunner.jar {chroot} && ls {chroot}",
@@ -13,41 +21,28 @@ shell_command(
   environment="__local_workspace__",
 
   # The `path_env_modify` field allows you to disable modification of the PATH environment
-  # variable by Pants. Since Bazel may incorporate the exact PATH value into its cache
-  # key, this reduces the non-deteriminsm to invoking Bazel to allow Bazel to use its 
-  # cache more effectively.
+  # variable by Pants. Since Bazel incorporates the exact PATH value into its cache
+  # keys, this allows Bazel to actually use its cache (versus having to rebuild everything each 
+  # time since the PATH will differ).
   path_env_modify="off",
 
   # Configure a longer timeout to give Bazel a chance to complete when necessary.
   timeout=600,
 )
 
-
-# The following two `system_binary` targets allow Pants to find Coursier.
-# The `run_shell_command` target below will use Coursier to execute the jar file
-# built by Bazel.
-system_binary(
-  name="sh",
-  binary_name="sh",
-)
-
-system_binary(
-  name="coursier",
-  binary_name="coursier",
-  fingerprint_args=["version"],
-  fingerprint_dependencies=[":sh"],
-)
-
-# Execute the jar file produced by Bazel.
-# - The jar file is visible to this target because it is listed as an
-#   "execution dependency."
-# - Coursier is made available on the PATH because the applicable `system_binary`
-#   target is listed as an `execution_dependency`.
-run_shell_command(
-  name="run-from-bazel",
-  command="coursier java -cp {chroot}/ProjectRunner.jar com.example.ProjectRunner",
-  execution_dependencies=[":bazel-jvm-binary"],
-  runnable_dependencies=[":coursier", ":sh"],
+# Build a Docker image which embeds the jar produced by Bazel via the //:bazel-jvm-binary target.
+# Note: The jar file is visible to this target because it is listed as a dependency.
+docker_image(
+  name="project_image",
+  instructions=[
+    "FROM openjdk:24-jdk-slim-bullseye",
+    "WORKDIR /app",
+    "COPY ProjectRunner.jar .",
+    'ENTRYPOINT ["java", "-cp", "ProjectRunner.jar", "com.example.ProjectRunner"]',
+  ],
+  dependencies=[
+    ":bazel-jvm-binary",
+  ],
 )
 
 # This target configures in-workspace execution support. A few points of note:

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ Some items to be aware of:
 
 1. Ensure you have Bazel and Docker both installed somewhere on the `PATH`.
 
-2. Run `pants package //:project_image`. This will produce a Docker image with the jar file produced by Bazel.
-
-3. Execute the Docker image: `docker run project_image:latest`. You should see the output: `Hello!`
+2. Run `pants run //:project_image`. This will produce a Docker image with the jar file produced by Bazel and run the resulting image.  You should see the output: `Hello!`
 
 ## Additional Reading
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This example project demonstrates the "in-workspace" execution support in Pants 
 
 ## Overview
 
-This example project integrates Pants with Bazel to build a small Java program. (Pants has Java support so this example is somewhat contrived, but the point is demonstrate integration with a third party build tool, not the particulars of the example.)
+This example project integrates Pants with Bazel to build a small Java program. (Pants has Java support so this example is very much contrived, but the point is demonstrate integration with a third party build tool, not to focus too much on details of this particular example.)
 
 Some items to be aware of:
 
@@ -14,8 +14,11 @@ Some items to be aware of:
 
 ## Running
 
-1. Run `pants run //:run-from-bazel`. The output should be the size of the
-   jar file captured from the in-workspace execution (as printed by `ls`).
+1. Ensure you have Bazel and Docker both installed somewhere on the `PATH`.
+
+2. Run `pants package //:project_image`. This will produce a Docker image with the jar file produced by Bazel.
+
+3. Execute the Docker image: `docker run project_image:latest`. You should see the output: `Hello!`
 
 ## Additional Reading
 

--- a/pants.toml
+++ b/pants.toml
@@ -3,6 +3,7 @@ pants_version = "2.23.0"
 backend_packages.add = [
   "pants.backend.shell",
   "pants.backend.experimental.adhoc",
+  "pants.backend.docker",
 ]
 pants_ignore = [
   # Ignore Bazel's output directories.
@@ -22,3 +23,6 @@ enabled = false
 
 [environments-preview.names]
 workspace = "//:workspace"
+
+[python]
+interpreter_constraints = ">=3.9"

--- a/pants.toml
+++ b/pants.toml
@@ -24,5 +24,9 @@ enabled = false
 [environments-preview.names]
 workspace = "//:workspace"
 
+# Note: Pants required this `interpreter_constraints` config for some reason even though Python
+# is not configured in this repository. Ordinarilly, you would pin a specific minor release of Python,
+# (e.g., `==3.9.*`) but since this repository is intended as a general example, this config accepts
+# any Python above v3.9 you may have in the interest of not forcing a specific Python version on you.
 [python]
 interpreter_constraints = ">=3.9"


### PR DESCRIPTION
Consume the jar file in a Docker image to demonstrate using the output with another target.